### PR TITLE
Incorporate feedback from SRV6OPS author meeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# SID Space (5f00::/16) Experiment
+# SID Space (5f00::/16) Inter-domain Addressing Recommendations
 
-This is the working area for the individual Internet-Draft, "SID Space (5f00::/16) Experiment".
+This is the working area for the individual Internet-Draft, "SID Space (5f00::/16) Inter-domain Addressing Recommendations".
 
 * [Editor's Copy](https://ipvsix.github.io/draft-sidspace-experiment/#go.draft-ek-srv6ops-sidspace-experiment.html)
 * [Datatracker Page](https://datatracker.ietf.org/doc/draft-ek-srv6ops-sidspace-experiment)

--- a/draft-ek-srv6ops-sidspace-experiment.md
+++ b/draft-ek-srv6ops-sidspace-experiment.md
@@ -1,7 +1,7 @@
 ---
 title: "SID Space (5f00::/16) Inter-domain Addressing Recommendations"
 abbrev: "SID Space Inter-domain Addressing."
-category: inf
+category: info
 
 docname: draft-ek-srv6ops-sidspace-experiment-latest
 submissiontype: IETF  # also: "independent", "editorial", "IAB", or "IRTF"

--- a/draft-ek-srv6ops-sidspace-experiment.md
+++ b/draft-ek-srv6ops-sidspace-experiment.md
@@ -1,7 +1,7 @@
 ---
-title: "SID Space (5f00::/16) Experiment"
-abbrev: "SID Space Exp."
-category: exp
+title: "SID Space (5f00::/16) Inter-domain Addressing Recommendations"
+abbrev: "SID Space Inter-domain Addressing."
+category: inf
 
 docname: draft-ek-srv6ops-sidspace-experiment-latest
 submissiontype: IETF  # also: "independent", "editorial", "IAB", or "IRTF"
@@ -33,9 +33,7 @@ author:
     email: buraglio@forwardingplane.net
 
 normative:
-  I-D.ietf-6man-sids:
-    target: https://datatracker.ietf.org/doc/draft-ietf-6man-sids/
-    title: "SRv6 Segment Identifiers in the IPv6 Addressing Architecture"
+  RFC9602:
   IANA-IPv6Special:
     target: https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xhtml
     title: "IANA IPv6 Special-Purpose Address Registry"
@@ -56,31 +54,35 @@ informative:
 
 --- abstract
 
-This specification proposes an experimental structure for use of the SRv6 SIDs prefix in support of Inter-Domain SRv6 networks.
+This specification recommends a specific structured use of the SRv6 SIDs prefix in support of Inter-Domain SRv6 networks.
 The core of the proposal is to structure the address space by Autonomous System Number (ASN).
 
 Use of this proposed structure is entirely voluntary.
-The goal of this experiment is to aid SRv6 operations while preserving the ability to use this prefix across cooperating SRv6 domains, but not across the general Internet.
+Voluntary use of this structure aids SRv6 operations while preserving the ability to use this prefix across cooperating SRv6 domains, but not across the general Internet.
 
 --- middle
 
 # Introduction
 
-[I-D.ietf-6man-sids] requested of IANA a dedicated prefix for Segment Routing over IPv6 [RFC8402] Segment Identifiers (SRv6 SIDs), with the aim of "improv\[ing\] security by making it simpler to filter traffic at the edge of the SR domains."
+[RFC9602] requested of IANA a dedicated prefix for Segment Routing over IPv6 [RFC8402] Segment Identifiers (SRv6 SIDs), with the aim of "improv\[ing\] security by making it simpler to filter traffic at the edge of the SR domains."
 The prefix 5f00::/16 was allocated for this purpose [IANA-IPv6Special].
 No requirements were placed on the use of this prefix nor any recommendations made for structured use of this prefix.
 
-This specification proposes an experimental structure for use of the SRv6 SIDs prefix in support of Inter-Domain SRv6 networks.
+This specification recommends a specific structured use of the SRv6 SIDs prefix in support of Inter-Domain SRv6 networks.
 The core of the proposal is to structure the address space by Autonomous System Number (ASN).
 
 Use of this proposed structure is entirely voluntary.
-The goal is to aid SRv6 operations while preserving the ability to use this prefix across cooperating SRv6 domains, but not across the general Internet.
+Voluntary use of this structure aids SRv6 operations while preserving the ability to use this prefix across cooperating SRv6 domains, but not across the general Internet.
 
 The SID space prefix was allocated to improve ease of filtering.
 Where SRv6 traffic using these prefixes may be shared with cooperating partner networks,
 this proposal makes it easier to craft filters that permit only SRv6 traffic from identified ASNs.
 
 As a point of historical interest, this proposal contains echos of the structure of the original 6bone test allocation [RFC1897].
+
+# Inter-domain SRv6 SIDs
+
+An inter-domain SRv6 SID, as used in this document, means an SRv6 SID from the address space used by one SRv6 domain that is advertised to another SRv6 domain force inclusion an SRv6 Policy used by the second domain when forwarding policy-specific traffic to the advertising SRv6 domain.
 
 # Proposed Structure
 
@@ -136,7 +138,7 @@ or any /48 prefix between these, as private use ASN-derived SID prefixes.
 
 # Routing and Filtering
 
-As noted in [draft-bdmgct-spring-srv6-security], it is assumed that each ASN participating in the SRv6 SID space experiment has deployed their respective SRv6 implementations within a limited domain [RFC8799] with appropriate filtering at the domain boundaries. Because this is a shared space experiment, the requisite filtering exceptions must be made between each SRv6 domain to allow for the desired Inter-Domain communication to occur. Care should be taken to allow only the desired and necessary communication between each SRv6 domain. The mechanisms used should be conformant with the given domain's security policy and may include, but are not limited to:
+As noted in [draft-bdmgct-spring-srv6-security], it is assumed that each ASN using this SRv6 SID space structure has deployed their respective SRv6 implementations within a limited domain [RFC8799] with appropriate filtering at the domain boundaries. Because this is intended for inter-domain use, the requisite filtering exceptions must be made between each SRv6 domain to allow for the desired Inter-Domain communication to occur. Care should be taken to allow only the desired and necessary communication between each SRv6 domain. The mechanisms used should be conformant with the given domain's security policy and may include, but are not limited to:
 
 * routing filters such as BGP prefix-lists, route-maps, route-policies, or other analogous mechanisms, or
 * access control filters at the domain edge
@@ -167,9 +169,6 @@ One possible test case is the exchange of the IPv6 prefix SID between two autono
 
 Within this structure, appropriate and agreed upon policy may be shared between the partner ASNs. Defining the policy or use cases is outside of the scope of this document.
 
-# Evaluating the Experiment
-
-A survey of participants in the experiment and subsequent evaluation of the results will determine the ease of deployment and operation, or lack thereof, and will inform if further work can be performed to improve ease of implementation and operation.
 
 # Security Considerations
 


### PR DESCRIPTION
Includes:
* change document target track to Informational
* initial attempt to define "inter-domain SRv6 SID"
* clean up various "experiment"/"experimental" wording and text

Note: the name of the file should also be changed, but this PR doesn't do that.